### PR TITLE
fix(wzn): rename dtype to torch_dtype in for transformers compatibility

### DIFF
--- a/lightrft/models/grm_vl.py
+++ b/lightrft/models/grm_vl.py
@@ -65,7 +65,7 @@ class GenerativeRewardModelVL(nn.Module):
                 pretrain_or_model,
                 trust_remote_code=True,
                 attn_implementation=attn_implementation,
-                dtype=torch.bfloat16 if bf16 else "auto",
+                torch_dtype=torch.bfloat16 if bf16 else "auto",
                 device_map=device_map,
             )
 

--- a/lightrft/models/srm_vl.py
+++ b/lightrft/models/srm_vl.py
@@ -82,7 +82,7 @@ class ScalarRewardModelVL(nn.Module):
                 pretrain_or_model,
                 trust_remote_code=True,
                 attn_implementation=attn_implementation,
-                dtype=torch.bfloat16 if bf16 else "auto",
+                torch_dtype=torch.bfloat16 if bf16 else "auto",
                 device_map=device_map,
             )
 


### PR DESCRIPTION
- Update GenerativeRewardModelVL and ScalarRewardModelVL to use 'torch_dtype' instead of 'dtype' when initializing from pretrained models. This fixes compatibility issues with transformers library of 4.51.3 version.