### PR TITLE
fix(wzn): remove redundant tuple nesting in prepare_reward_model return when using FSDP

### DIFF
--- a/lightrft/strategy/strategy_base.py
+++ b/lightrft/strategy/strategy_base.py
@@ -627,7 +627,8 @@ class StrategyBase(ABC):
                 is_rlhf=True,
             )
         else:
-            return ((reward_model, reward_model_optim, reward_model_scheduler), )
+            # For FSDP: return wrapped model and optimizers
+            return reward_model, reward_model_optim, reward_model_scheduler
 
     @classmethod
     def report_memory(cls, prefix=""):


### PR DESCRIPTION
- Removing redundant tuple nesting in the return structure of  `prepare_reward_model`  when FSDP is enabled to avoid unpacking bug